### PR TITLE
TSDK-83 Fix bug

### DIFF
--- a/daml/Main.daml
+++ b/daml/Main.daml
@@ -11,42 +11,44 @@ import DA.Optional
 
 initialize : Script [Party]
 initialize = do
-      -- operator <- allocateParty "operator"
-      -- operatorId <- validateUserId "operator"
-      -- alice <- allocateParty "Alice"
-      -- aliceId <- validateUserId "alice"
-      -- bob <- allocateParty "Bob"
-      -- bobId <- validateUserId "bob"
-      -- eve <- allocateParty "Eve"
-      -- eveId <- validateUserId "eve"
-      -- operatorCid <- submit operator do
-      --   createCmd Operator with operator = operator, address = "AUANVY6RqbJtTnQS1AFTQBjXMFYDknhV8NEixHFLmeZynMxVbp64"
-      -- orgCid <- submit operator do
-      --   exerciseCmd operatorCid Operator_CreateOrganization
-      --     with orgName = "Topl"
-      -- membershipOfferCid <- submit operator do
-      --   exerciseCmd orgCid Organization_InviteMember
-      --     with 
-      --       invitee = alice
-      -- membershipAcceptance <- submit alice do
-      --   exerciseCmd membershipOfferCid Membershp_Accept
-      -- submit operator do
-      --     exerciseCmd membershipAcceptance AddUserToOrganization
-      -- someOrg <- queryContractKey @Organization operator (operator, "Topl")
-      -- membershipOfferCid <- submit operator do
-      --   exerciseCmd (fromSome someOrg)._1 Organization_InviteMember
-      --     with invitee = bob
-      -- membershipAcceptance <- submit bob do
-      --   exerciseCmd membershipOfferCid Membershp_Accept
-      -- submit operator do
-      --     exerciseCmd membershipAcceptance AddUserToOrganization
-      -- userInvitationCid <- submit operator do
-      --   exerciseCmd operatorCid  Operator_InviteUser 
-      --     with user = alice
-      -- aliceUserCid <- submit alice do
-      --   exerciseCmd userInvitationCid UserInvitation_Accept
-      -- createUser (Daml.Script.User aliceId (Some alice)) [CanActAs alice]
-      -- createUser (Daml.Script.User operatorId (Some operator)) [CanActAs operator]
-      -- createUser (Daml.Script.User bobId (Some bob)) [CanActAs bob]
-      -- createUser (Daml.Script.User eveId (Some eve)) [CanActAs eve]
+      operator <- allocateParty "operator"
+      operatorId <- validateUserId "operator"
+      alice <- allocateParty "Alice"
+      aliceId <- validateUserId "alice"
+      bob <- allocateParty "Bob"
+      bobId <- validateUserId "bob"
+      eve <- allocateParty "Eve"
+      eveId <- validateUserId "eve"
+      operatorCid <- submit operator do
+        createCmd Operator with operator = operator, address = "AUANVY6RqbJtTnQS1AFTQBjXMFYDknhV8NEixHFLmeZynMxVbp64"
+      orgCid <- submit operator do
+        exerciseCmd operatorCid Operator_CreateOrganization
+          with 
+            orgId   = "1"
+            orgName = "Topl"
+      membershipOfferCid <- submit operator do
+        exerciseCmd orgCid Organization_InviteMember
+          with 
+            invitee = alice
+      membershipAcceptance <- submit alice do
+        exerciseCmd membershipOfferCid Membershp_Accept
+      submit operator do
+          exerciseCmd membershipAcceptance AddUserToOrganization
+      someOrg <- queryContractKey @Organization operator (operator, "1")
+      membershipOfferCid <- submit operator do
+        exerciseCmd (fromSome someOrg)._1 Organization_InviteMember
+          with invitee = bob
+      membershipAcceptance <- submit bob do
+        exerciseCmd membershipOfferCid Membershp_Accept
+      submit operator do
+          exerciseCmd membershipAcceptance AddUserToOrganization
+      userInvitationCid <- submit operator do
+        exerciseCmd operatorCid  Operator_InviteUser 
+          with user = alice
+      aliceUserCid <- submit alice do
+        exerciseCmd userInvitationCid UserInvitation_Accept
+      createUser (Daml.Script.User aliceId (Some alice)) [CanActAs alice]
+      createUser (Daml.Script.User operatorId (Some operator)) [CanActAs operator]
+      createUser (Daml.Script.User bobId (Some bob)) [CanActAs bob]
+      createUser (Daml.Script.User eveId (Some eve)) [CanActAs eve]
       pure []

--- a/daml/Tests/Asset.daml
+++ b/daml/Tests/Asset.daml
@@ -11,7 +11,7 @@ module Tests.Asset where
     org_create_asset_creator_test = script do
         -- we can reuse previous tests, this one creates two users in an organization
         (operator, alice, bob) <- org_add_two_member_test
-        someOrg <- queryContractKey @Organization operator (operator, "Topl")
+        someOrg <- queryContractKey @Organization operator (operator, "1")
         let orgId = (fromSome someOrg)._1
         let org = (fromSome someOrg)._2
         org <- submit alice do 
@@ -24,10 +24,10 @@ module Tests.Asset where
 
     asset_creator_mint_asset = script do
         (operator, alice, bob, org) <- org_create_asset_creator_test
-        someOrg <- queryContractKey @Organization operator (operator, "Topl")
+        someOrg <- queryContractKey @Organization operator (operator, "1")
         let orgId = (fromSome someOrg)._1
         let org = (fromSome someOrg)._2
-        someAssetCreator <- queryContractKey @AssetCreator operator (operator, "Topl", head org.assetCodes)
+        someAssetCreator <- queryContractKey @AssetCreator operator (operator, "1", (head org.assetCodesAndIous)._1)
         let assetCreatorCid = (fromSome someAssetCreator)._1
         assetMintingRequestCid <- submit alice do 
             exerciseCmd assetCreatorCid MintAsset with
@@ -58,11 +58,37 @@ module Tests.Asset where
         signedAssetMinting <- queryContractId operator signedAssetMintingCid
         assetIou <- submit operator do
             exerciseCmd orgId Organization_AddSignedAssetMinting with
+                iouIdentifier         = "1"
                 signedAssetMintingCid = signedAssetMintingCid
         someAssetIou <- queryContractId @AssetIou operator assetIou
         (fromSome someAssetIou).someMetadata === (Some "YYYY")
         (fromSome someAssetIou).someCommitRoot === (Some "XXXX")
         return (operator, alice, bob, assetIou)
+
+    asset_creator_add_member_after_iou = script do
+        (operator, alice, bob, assetIou)  <- asset_creator_mint_asset
+        someOrg <- queryContractKey @Organization operator (operator, "1")
+        let orgId = (fromSome someOrg)._1
+        let org = (fromSome someOrg)._2
+        eve <- allocateParty "Eve" 
+        membershiptOffer <- submit operator do
+            exerciseCmd orgId Organization_InviteMember with invitee = eve
+        membershipAcceptance <- submit eve do 
+            exerciseCmd membershiptOffer Membershp_Accept
+        submit operator do
+            exerciseCmd membershipAcceptance AddUserToOrganization
+        someAssetIou <- queryContractKey @AssetIou operator (operator, "1", (head org.assetCodesAndIous)._1, "1")
+        submit eve do
+            exerciseCmd (fromSome someAssetIou)._1 AssetIou_UpdateAsset with
+                requestor = eve
+                newCommitRoot = Some "WWWW"
+                newMetadata = Some "VVVVV"
+                someFee = None
+        someOrg <- queryContractKey @Organization operator (operator, "1")
+        let orgId = (fromSome someOrg)._1
+        let org = (fromSome someOrg)._2
+        assert (eve `elem` org.members)
+        return (operator, alice, bob, assetIou) 
 
     asset_creator_transfer_asset = script do
         (operator, alice, bob, assetIou)  <- asset_creator_mint_asset
@@ -92,11 +118,12 @@ module Tests.Asset where
                 txId = "XXXXX"
                 depth = 1
         someSignedAssetTransferCid <- queryContractId operator signedAssetTransferCid
-        someOrg <- queryContractKey @Organization operator (operator, "Topl")
+        someOrg <- queryContractKey @Organization operator (operator, "1")
         let orgId = (fromSome someOrg)._1
         let org = (fromSome someOrg)._2
         assetIou <- submit operator do
             exerciseCmd orgId Organization_AddSignedAssetTransfer with
+                iouIdentifier         = "1"
                 signedAssetTransferCid = signedAssetTransferCid
         someAssetIou <- queryContractId @AssetIou operator assetIou
         (fromSome someAssetIou).someMetadata === (Some "VVVVV")

--- a/daml/Tests/Organization.daml
+++ b/daml/Tests/Organization.daml
@@ -14,14 +14,16 @@ module Tests.Organization where
         operatorCid <- submit operator do
             createCmd Operator with operator = operator, address = "XXXX"
         org <- submit operator do
-            exerciseCmd operatorCid Operator_CreateOrganization with orgName = "Topl"
+            exerciseCmd operatorCid Operator_CreateOrganization with
+                                                                    orgId   = "1" 
+                                                                    orgName = "Topl"
         membershiptOffer <- submit operator do
             exerciseCmd org Organization_InviteMember with invitee = alice
         membershipAcceptance <- submit alice do
             exerciseCmd membershiptOffer Membershp_Accept
         submit operator do
             exerciseCmd membershipAcceptance AddUserToOrganization
-        someOrgData <-  queryContractKey @Organization alice (operator, "Topl")
+        someOrgData <-  queryContractKey @Organization alice (operator, "1")
         assertMsg "alice is not in members" (alice `elem` (fromSomeNote "No org data" someOrgData)._2.members)
         assertMsg "alice is in wouldBeMembers" (alice `notElem` (fromSomeNote "No org data for would be members" someOrgData)._2.wouldBeMembers)
 
@@ -34,14 +36,16 @@ module Tests.Organization where
         operatorCid <- submit operator do
             createCmd Operator with operator = operator, address = "XXXX"
         org <- submit operator do
-            exerciseCmd operatorCid Operator_CreateOrganization with orgName = "Topl"
+            exerciseCmd operatorCid Operator_CreateOrganization with
+                                                                    orgId   = "1" 
+                                                                    orgName = "Topl"
         membershiptOffer <- submit operator do
             exerciseCmd org Organization_InviteMember with invitee = alice
         membershipAcceptance <- submit alice do
             exerciseCmd membershiptOffer Membershp_Accept
         org <- submit operator do
             exerciseCmd membershipAcceptance AddUserToOrganization
-        someOrg <- queryContractKey @Organization operator (operator, "Topl")
+        someOrg <- queryContractKey @Organization operator (operator, "1")
         membershiptOffer <- submit operator do
             exerciseCmd (fromSome someOrg)._1 Organization_InviteMember with invitee = bob
         membershipAcceptance <- submit bob do
@@ -64,10 +68,12 @@ module Tests.Organization where
         operatorCid <- submit operator do
             createCmd Operator with operator = operator, address = "XXXX"
         org <- submit operator do
-            exerciseCmd operatorCid Operator_CreateOrganization with orgName = "Topl"
+            exerciseCmd operatorCid Operator_CreateOrganization with 
+                                                                orgId   = "1"
+                                                                orgName = "Topl"
         membershiptOfferAlice <- submit operator do
             exerciseCmd org Organization_InviteMember with invitee = alice
-        newOrg <- queryContractKey @Organization operator (operator, "Topl")
+        newOrg <- queryContractKey @Organization operator (operator, "1")
         membershiptOfferBob <- submit operator do
             exerciseCmd (fromSome newOrg)._1 Organization_InviteMember with invitee = bob
         membershipAcceptance <- submit alice do
@@ -76,7 +82,7 @@ module Tests.Organization where
         -- we need this step because if this is performed by a user, it will fail. Indeed, each user does not have the right to see the membership invitation
         submit operator do
             exerciseCmd membershipAcceptance AddUserToOrganization
-        someMembershipOfferForBob <-  queryContractKey @MembershipOffer operator (operator, bob, "Topl")
+        someMembershipOfferForBob <-  queryContractKey @MembershipOffer operator (operator, bob, "1")
         membershipAcceptance <- submit bob do
             exerciseCmd (fromSomeNote "No offer found for Bob" someMembershipOfferForBob)._1 Membershp_Accept
         org <- submit operator do

--- a/daml/Topl/Asset.daml
+++ b/daml/Topl/Asset.daml
@@ -26,7 +26,7 @@ module Topl.Asset where
         with 
             operator             : Party
             requestor            : Party
-            someOrgName          : Optional Text
+            someOrgId            : Optional Text
             from                 : [Text]
             to                   : [(Text, Int)]
             changeAddress        : Text
@@ -59,7 +59,7 @@ module Topl.Asset where
         with 
             operator             : Party
             requestor            : Party
-            someOrgName          : Optional Text
+            someOrgId            : Optional Text
             from                 : [Text]
             to                   : [(Text, Int)]
             changeAddress        : Text
@@ -93,7 +93,7 @@ module Topl.Asset where
         with 
             operator             : Party
             requestor            : Party
-            someOrgName          : Optional Text
+            someOrgId            : Optional Text
             from                 : [Text]
             to                   : [(Text, Int)]
             changeAddress        : Text
@@ -150,7 +150,7 @@ module Topl.Asset where
         with 
             operator             : Party
             requestor            : Party
-            someOrgName          : Optional Text
+            someOrgId            : Optional Text
             from                 : [Text]
             to                   : [(Text, Int)]
             changeAddress        : Text
@@ -185,7 +185,7 @@ module Topl.Asset where
         with 
             operator             : Party
             requestor            : Party
-            someOrgName          : Optional Text
+            someOrgId            : Optional Text
             from                 : [Text]
             to                   : [(Text, Int)]
             changeAddress        : Text
@@ -221,7 +221,7 @@ module Topl.Asset where
         with 
             operator             : Party
             requestor            : Party
-            someOrgName          : Optional Text
+            someOrgId          : Optional Text
             from                 : [Text]
             to                   : [(Text, Int)]
             changeAddress        : Text

--- a/daml/Topl/Onboarding.daml
+++ b/daml/Topl/Onboarding.daml
@@ -27,6 +27,7 @@ module Topl.Onboarding where
 
             nonconsuming choice Operator_CreateOrganization : OrganizationCid
                 with
+                    orgId           : Text
                     orgName         : Text
                 controller operator
                 do
@@ -34,7 +35,7 @@ module Topl.Onboarding where
                         with 
                             wouldBeMembers = []
                             members = []
-                            assetCodes = []
+                            assetCodesAndIous = []
                             ..
 
 

--- a/daml/Topl/Organization.daml
+++ b/daml/Topl/Organization.daml
@@ -22,12 +22,14 @@ module Topl.Organization where
     template AssetCreator
         with
             operator     : Party
-            organization : Organization
+            orgId        : Text
+            address      : Text
+            members      : [ Party ]
             assetCode    : AssetCode
                 where
-                    signatory operator, organization.members
+                    signatory operator, members
 
-                    key (operator, organization.orgName, assetCode): (Party, Text, AssetCode)
+                    key (operator, orgId, assetCode): (Party, Text, AssetCode)
 
                     maintainer key._1
                     ensure
@@ -44,15 +46,15 @@ module Topl.Organization where
                             someFee              : Optional Int
                                 controller requestor
                                     do 
-                                        assert (requestor `elem` organization.members)
+                                        assert (requestor `elem` members)
                                         -- the creation of the AssetMintingRequest requires the signature of the requestor
                                         -- thus guaranteeing that I cannot request a Minting request
                                         -- on behalf of someone else
                                         create AssetMintingRequest with 
-                                            someOrgName   = Some organization.orgName
-                                            from          = [ organization.address ]
-                                            to            = [ (organization.address, quantity)]
-                                            changeAddress = organization.address
+                                            someOrgId     = Some orgId
+                                            from          = [ address ]
+                                            to            = [ (address, quantity)]
+                                            changeAddress = address
                                             fee           = fromOptional 100 someFee -- we set a default fee
                                             ..
 
@@ -60,18 +62,19 @@ module Topl.Organization where
 
     template Organization
         with
-            orgName         : Text
-            address         : Text
-            operator        : Party
-            wouldBeMembers  : [ Party ] 
-            members         : [ Party ]
-            assetCodes      : [ AssetCode ] 
+            orgId             : Text
+            orgName           : Text
+            address           : Text
+            operator          : Party
+            wouldBeMembers    : [ Party ] 
+            members           : [ Party ]
+            assetCodesAndIous : [ (AssetCode, [ Text ]) ] 
         where
             signatory operator, members
 
             observer wouldBeMembers
 
-            key (operator, orgName) : (Party, Text)
+            key (operator, orgId) : (Party, Text)
             maintainer key._1
             ensure 
                 (unique members) && 
@@ -87,9 +90,9 @@ module Topl.Organization where
 
                     create this with  wouldBeMembers = invitee :: wouldBeMembers
                     create MembershipOffer with 
-                        organization = this
                         ..
-            nonconsuming choice Organization_AddSignedAssetMinting: AssetIouCid with
+            choice Organization_AddSignedAssetMinting: AssetIouCid with
+                    iouIdentifier         : Text
                     signedAssetMintingCid : SignedAssetMintingCid
                 controller operator
                 do
@@ -97,19 +100,23 @@ module Topl.Organization where
                     -- we make sure that the asset minting was requested by a member of the organization
                     assert (signedAssetMinting.requestor `elem` members)
                     -- we check that the org name for this minting is the same as the current org
-                    assert (optional True  ( == this.orgName) signedAssetMinting.someOrgName)
+                    assert (optional True  ( == this.orgId) signedAssetMinting.someOrgId)
                     archive signedAssetMintingCid
 
-                    create  AssetIou with
-                        organization    = this
+                    resultIou <- create  AssetIou with
                         assetCode       = signedAssetMinting.assetCode
                         quantity        = signedAssetMinting.quantity
                         someMetadata    = signedAssetMinting.someMetadata
                         someCommitRoot  = signedAssetMinting.someCommitRoot
                         boxNonce        = signedAssetMinting.boxNonce
                         ..
+                    create this with assetCodesAndIous =  map (\assetAndIou -> 
+                                            if (assetAndIou._1 ==  signedAssetMinting.assetCode) then (assetAndIou._1, iouIdentifier :: assetAndIou._2) else  assetAndIou)
+                                            assetCodesAndIous
+                    return resultIou
 
-            nonconsuming choice Organization_AddSignedAssetTransfer: AssetIouCid with
+            choice Organization_AddSignedAssetTransfer: AssetIouCid with
+                    iouIdentifier          : Text
                     signedAssetTransferCid : SignedAssetTransferCid
                 controller operator
                 do
@@ -117,47 +124,69 @@ module Topl.Organization where
                     -- we make sure that the asset minting was requested by a member of the organization
                     assert (signedAssetTransfer.requestor `elem` members)
                     -- we check that the org name for this minting is the same as the current org
-                    assert (optional True ( == this.orgName) signedAssetTransfer.someOrgName)
+                    assert (optional True ( == this.orgId) signedAssetTransfer.someOrgId)
                     archive signedAssetTransferCid
-                    create  AssetIou with
-                        organization    = this
+                    resultIou <- create  AssetIou with
                         assetCode       = signedAssetTransfer.assetCode
                         quantity        = signedAssetTransfer.quantity
                         someMetadata    = signedAssetTransfer.someMetadata
                         someCommitRoot  = signedAssetTransfer.someCommitRoot
                         boxNonce        = signedAssetTransfer.boxNonce
                         ..
+                    create this with assetCodesAndIous =  map (\assetAndIou -> 
+                                                                if (assetAndIou._1 ==  signedAssetTransfer.assetCode) then (assetAndIou._1, iouIdentifier :: assetAndIou._2) else  assetAndIou)
+                                                                assetCodesAndIous
+                    return resultIou
 
 
             choice Organization_Update : OrganizationCid
                 controller operator
                 do
                     -- we remove the invitee from the would be members
-                    let currentAssets = assetCodes
+                    let currentAssets = map (\x -> x._1) assetCodesAndIous
                     -- we need to invite all would be members again, since the old invitations will not work
-                    idsAndinvitations <- mapA (\i -> fetchByKey @MembershipOffer (operator, i, orgName)) wouldBeMembers
+                    idsAndinvitations <- mapA (\i -> fetchByKey @MembershipOffer (operator, i, orgId)) wouldBeMembers
                     let existingInvitationIds = map (\x -> x._1) idsAndinvitations
                     -- we archive the old invitations
                     archived <- mapA
                         (\invitationId -> archive invitationId) 
                         existingInvitationIds                
                     -- archive existing asset contracts
-                    idAndCreators <- mapA (\assetCode -> fetchByKey @AssetCreator (operator, orgName, assetCode)) assetCodes
+                    idAndCreators <- mapA (\assetCodesAndIou -> fetchByKey @AssetCreator (operator, orgId, assetCodesAndIou._1)) assetCodesAndIous
                     let existingAssetCreatorsId = map (\x -> x._1) idAndCreators
                     archived <- mapA
                         (\assetCreatorsId -> archive assetCreatorsId) 
                         existingAssetCreatorsId
                     -- this recreates all the asset creators
                     newOrg <- foldr 
-                        (\assetCode updateOp -> 
+                        (\assetCodeAndIou updateOp -> 
                                 (updateOp >>= -- this is a haskell flatMap
                                     (\newOrg -> exercise 
                                         newOrg Organization_CreateAsset with 
                                             requestor = head members
-                                            version = assetCode.version
-                                            shortName = assetCode.shortName)))
-                        (create this with wouldBeMembers = [], members = members,  assetCodes = [])
-                        assetCodes
+                                            version = assetCodeAndIou._1.version
+                                            shortName = assetCodeAndIou._1.shortName)))
+                        (create this with wouldBeMembers = [], members = members,  assetCodesAndIous = assetCodesAndIous)
+                        assetCodesAndIous
+                    -- we need to recreate all asset IOUs
+                    listOfAssetIou <- mapA (\x -> fetchByKey @AssetIou (operator, orgId, x._1, x._2)) (assetCodesAndIous >>= (\pair -> map (\iou -> (pair._1, iou)) pair._2)) 
+                    -- archive all old IoUs
+                    archived <- mapA (\x -> archive x._1) listOfAssetIou
+                    newOrgData <- fetch @Organization newOrg
+                    -- we recreate the IoUs
+                    created <- mapA ((\x -> 
+                                create AssetIou with 
+                                    operator = x.operator
+                                    iouIdentifier = x.iouIdentifier
+                                    quantity = x.quantity
+                                    someMetadata = x.someMetadata
+                                    assetCode = x.assetCode
+                                    someCommitRoot = x.someCommitRoot
+                                    boxNonce = x.boxNonce
+                                    ..
+                                ) . (\x -> x._2))
+                        listOfAssetIou
+                    
                     -- this recreates all new invitations using the new members
                     -- this is necessary, because all members need to sign to add a member, an organization
                     -- is a contract among all members
@@ -182,22 +211,26 @@ module Topl.Organization where
                                         shortName = shortName
                     create AssetCreator with
                         operator = operator
-                        organization = this
                         assetCode = asset
-                    create this with assetCodes =   asset :: assetCodes
+                        ..
+                    if (not (any ((== asset) . (\x -> x._1)) assetCodesAndIous)) then
+                        create this with assetCodesAndIous =   (asset, []) ::  assetCodesAndIous
+                    else 
+                        create this with assetCodesAndIous =   assetCodesAndIous
 
     template MembershipAcceptance
         with
             operator        : Party
             invitee         : Party
-            organization    : Organization
+            orgId           : Text
+            members         : [ Party ]
         where
-            signatory operator, invitee, organization.members
+            signatory operator, invitee, members
 
             choice AddUserToOrganization: OrganizationCid
                 controller operator
                     do
-                        existingContract <- fetchByKey  @Organization (operator,  organization.orgName)
+                        existingContract <- fetchByKey  @Organization (operator,  orgId)
                         archive existingContract._1
                         newContract <- create existingContract._2
                             with 
@@ -208,11 +241,12 @@ module Topl.Organization where
     template MembershipOffer
         with
             operator        : Party
-            organization    : Organization
+            orgId           : Text
+            members         : [ Party ]
             invitee         : Party
         where
-            signatory operator, organization.members
-            key (operator, invitee, organization.orgName): (Party, Party, Text)
+            signatory operator, members
+            key (operator, invitee, orgId): (Party, Party, Text)
 
             maintainer key._1
 
@@ -237,14 +271,21 @@ module Topl.Organization where
     template AssetIou
         with
             operator        : Party
-            organization    : Organization
+            orgId           : Text
+            members         : [ Party ]
+            address         : Text
+            iouIdentifier   : Text
             quantity        : Int
             someMetadata    : Optional Text
             assetCode       : AssetCode
             someCommitRoot  : Optional Text
             boxNonce        : Int
                 where
-                    signatory operator, organization.members
+                    signatory operator, members
+
+                    key (operator, orgId, assetCode, iouIdentifier): (Party, Text, AssetCode, Text)
+
+                    maintainer key._1
 
                     choice AssetIou_UpdateAsset: AssetTransferRequestCid
                         with 
@@ -254,12 +295,12 @@ module Topl.Organization where
                             someFee         : Optional Int
                         controller requestor
                         do
-                            assert (requestor `elem` organization.members)
+                            assert (requestor `elem` members)
                             create AssetTransferRequest with 
-                                from           = [ organization.address ]
-                                to             = [ (organization.address, quantity)]
-                                someOrgName    = Some organization.orgName
-                                changeAddress  = organization.address
+                                from           = [ address ]
+                                to             = [ (address, quantity)]
+                                someOrgId      = Some orgId
+                                changeAddress  = address
                                 someCommitRoot =  orElse newCommitRoot someCommitRoot 
                                 someMetadata   = orElse newMetadata someMetadata 
                                 fee            = fromOptional 100 someFee -- we set a default fee

--- a/src/main/java/co/topl/daml/AssetOperatorMain.java
+++ b/src/main/java/co/topl/daml/AssetOperatorMain.java
@@ -21,6 +21,7 @@ import co.topl.daml.assets.processors.SignedAssetTransferRequestProcessor;
 import akka.actor.ActorSystem;
 import co.topl.client.Provider;
 import akka.http.javadsl.model.Uri;
+import java.util.function.Supplier;
 
 import io.reactivex.Flowable;
 import co.topl.daml.DamlAppContext;
@@ -68,8 +69,16 @@ public class AssetOperatorMain {
 		UnsignedMintingRequestProcessor unsignedMintingRequestProcessor = new UnsignedMintingRequestProcessor(
 				damlAppContext, toplContext, keyfile, password);
 		transactions.forEach(unsignedMintingRequestProcessor::processTransaction);
+		Supplier<String> supplier = new Supplier<String>() {
+
+			int i = 0;
+
+			public String get() {
+				return Integer.valueOf(i++).toString();
+			}
+		};
 		SignedMintingRequestProcessor signedMintingRequestProcessor = new SignedMintingRequestProcessor(damlAppContext,
-				toplContext);
+				toplContext, supplier);
 		transactions.forEach(signedMintingRequestProcessor::processTransaction);
 
 		AssetTransferRequestProcessor assetTransferRequestProcessor = new AssetTransferRequestProcessor(damlAppContext,
@@ -79,7 +88,7 @@ public class AssetOperatorMain {
 				damlAppContext, toplContext, keyfile, password);
 		transactions.forEach(unsignedTransferRequestProcessor::processTransaction);
 		SignedAssetTransferRequestProcessor signedTransferRequestProcessor = new SignedAssetTransferRequestProcessor(
-				damlAppContext, toplContext);
+				damlAppContext, toplContext, supplier);
 		transactions.forEach(signedTransferRequestProcessor::processTransaction);
 	}
 }

--- a/src/main/scala/co/topl/daml/assets/processors/SignedAssetTransferRequestProcessor.scala
+++ b/src/main/scala/co/topl/daml/assets/processors/SignedAssetTransferRequestProcessor.scala
@@ -49,9 +49,14 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.io.Source
 
+// Possible designs:
+// - One-off processor
+// - Reusable processor
+
 class SignedAssetTransferRequestProcessor(
   damlAppContext: DamlAppContext,
-  toplContext:    ToplContext
+  toplContext:    ToplContext,
+  idGenerator:    java.util.function.Supplier[String]
 ) extends AbstractProcessor(damlAppContext, toplContext) {
 
   implicit val networkPrefix = toplContext.provider.networkPrefix
@@ -147,8 +152,8 @@ class SignedAssetTransferRequestProcessor(
 
       stream.Stream.of(
         Organization
-          .byKey(new types.Tuple2(signedTransferRequest.operator, signedTransferRequest.someOrgName.get()))
-          .exerciseOrganization_AddSignedAssetTransfer(signedTransferRequestContract)
+          .byKey(new types.Tuple2(signedTransferRequest.operator, signedTransferRequest.someOrgId.get()))
+          .exerciseOrganization_AddSignedAssetTransfer(idGenerator.get(), signedTransferRequestContract)
       )
     } else {
       stream.Stream.of(

--- a/src/main/scala/co/topl/daml/assets/processors/SignedMintingRequestProcessor.scala
+++ b/src/main/scala/co/topl/daml/assets/processors/SignedMintingRequestProcessor.scala
@@ -54,7 +54,8 @@ import scala.io.Source
 
 class SignedMintingRequestProcessor(
   damlAppContext: DamlAppContext,
-  toplContext:    ToplContext
+  toplContext:    ToplContext,
+  idGenerator:    java.util.function.Supplier[String]
 ) extends AbstractProcessor(damlAppContext, toplContext) {
 
   implicit val networkPrefix = toplContext.provider.networkPrefix
@@ -152,8 +153,8 @@ class SignedMintingRequestProcessor(
 
       stream.Stream.of(
         Organization
-          .byKey(new types.Tuple2(signedMintingRequest.operator, signedMintingRequest.someOrgName.get()))
-          .exerciseOrganization_AddSignedAssetMinting(signedMintingRequestContract)
+          .byKey(new types.Tuple2(signedMintingRequest.operator, signedMintingRequest.someOrgId.get()))
+          .exerciseOrganization_AddSignedAssetMinting(idGenerator.get(), signedMintingRequestContract)
       )
     } else {
       stream.Stream.of(


### PR DESCRIPTION
# Purpose

The purpose of this PR is to fix the following problem. When one adds a new member to an organization. The system does not update the AssetIOUs to have the new member as signatory. The new member cannot perform operations in the asset IOU.

# Approach

We corrected the bug and also improved a few issues with organization contracts. In particular, we added the `orgId` field to the Organization as the main identifier.

# Testing

We added the test `asset_creator_add_member_after_iou` to the Asset test file.

# Tickets

- [TSDK-83](https://topl.atlassian.net/browse/TSDK-83)